### PR TITLE
fix: Resolve E2E test timeout (post-merge hotfix)

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -74,6 +74,7 @@ export default defineConfig({
     stderr: 'pipe',
     env: {
       VITE_OPEN_BROWSER: 'false',
+      PORT: '3000', // Force port 3000 for E2E tests (prevents auto-increment)
     },
   },
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -81,6 +81,7 @@ export default defineConfig(({ mode }) => {
     // Development server
     server: {
       port: env.PORT ? parseInt(env.PORT) : 3000, // Use PORT env var or default to 3000
+      strictPort: isCI, // Fail if port unavailable on CI (prevents Playwright port mismatch)
       host: true,
       open: shouldAutoOpen && !isCI,
 


### PR DESCRIPTION
## 🐛 Problem
After PR #52 merge, E2E tests timeout in CI (120 seconds waiting for dev server).

## 🔍 Root Cause
**Port mismatch:**
- Playwright expects: `http://localhost:3000`
- Vite uses: `http://localhost:3003` (auto-incremented when 3000 occupied)
- Result: 120-second timeout

## ✅ Solution
```diff
# playwright.config.ts
+      PORT: '3000', // Force port 3000 for E2E tests

# vite.config.ts  
+      strictPort: isCI, // Fail if port unavailable on CI
```

## 🧪 Test Results
- ✅ E2E tests: 2 passed, 1 skipped (29.1s) 
- ✅ Unit tests: 107 passed, 17 skipped
- ✅ TypeScript: 0 errors
- ✅ ESLint: 0 errors, 0 warnings

## 📊 Changes
**Only 2 lines changed** (1 per file)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured end-to-end tests to run on a consistent port.
  * Updated development server configuration to enforce strict port availability in CI environments, ensuring builds fail if the port is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->